### PR TITLE
Fixing Hubble ServiceMonitor k8s-app label

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent-servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent-servicemonitor.yaml
@@ -36,7 +36,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: cilium
+      k8s-app: hubble
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}


### PR DESCRIPTION
The current ServiceMonitor is trying to match a `k8s-app=cilium`, but the current service has `k8s-app=hubble`.
https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/templates/cilium-agent-service.yaml#L56

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!
